### PR TITLE
Implemented icon widget

### DIFF
--- a/lib/routes/icon.dart
+++ b/lib/routes/icon.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class IconImplementation extends StatelessWidget {
+  const IconImplementation({Key? key}) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: const <Widget>[
+              Icon(
+                Icons.favorite,
+                color: Colors.pink,
+                size: 36.0,
+              ),
+              Icon(
+                Icons.audiotrack,
+                color: Colors.green,
+                size: 36.0,
+              ),
+              Icon(
+                Icons.beach_access,
+                color: Colors.blue,
+                size: 36.0,
+              ),
+            ],
+          ),
+
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: const <Widget>[
+              Icon(
+                Icons.ac_unit,
+                color: Colors.blue,
+                size: 36.0,
+              ),
+              Icon(
+                Icons.access_alarm,
+                color: Colors.pinkAccent,
+                size: 36.0,
+              ),
+              Icon(
+                Icons.access_time_filled,
+                color: Colors.teal,
+                size: 36.0,
+              ),
+            ],
+          ),
+
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: const <Widget>[
+              Icon(
+                Icons.accessibility,
+                color: Colors.indigo,
+                size: 36.0,
+              ),
+              Icon(
+                Icons.accessible,
+                color: Colors.green,
+                size: 36.0,
+              ),
+              Icon(
+                Icons.accessible_forward,
+                color: Colors.blue,
+                size: 36.0,
+              ),
+            ],
+          ),
+
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: const <Widget>[
+              Icon(
+                Icons.account_balance,
+                color: Colors.blueGrey,
+                size: 36.0,
+              ),
+              Icon(
+                Icons.account_balance_wallet,
+                color: Colors.amber,
+                size: 36.0,
+              ),
+              Icon(
+                Icons.account_box,
+                color: Colors.blue,
+                size: 36.0,
+              ),
+            ],
+          ),
+
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: const <Widget>[
+              Icon(
+                Icons.account_tree,
+                color: Colors.black87,
+                size: 36.0,
+              ),
+              Icon(
+                Icons.adb,
+                color: Colors.green,
+                size: 36.0,
+              ),
+              Icon(
+                Icons.add,
+                color: Colors.pink,
+                size: 36.0,
+              ),
+            ],
+          ),
+
+        ],
+      ),
+    );
+  }
+}
+
+class IconDescription extends StatelessWidget {
+  const IconDescription({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text(
+        'Flutter allows us to use variety of icons.\n\n To list a few we have: favourite, audiotrack, beach_access, ac_unit, access_alarm, access_time, accessibility, adb, add... and the list goes on and on.',
+        style: TextStyle(),
+        textAlign: TextAlign.center,
+      ),
+    );
+  }
+}

--- a/lib/widget_list.dart
+++ b/lib/widget_list.dart
@@ -4,6 +4,7 @@ import 'package:flutterista/models/widget_window.dart';
 import 'package:flutterista/routes/appBar.dart';
 import 'package:flutterista/routes/column.dart';
 import 'package:flutterista/routes/image.dart';
+import 'package:flutterista/routes/icon.dart';
 import 'routes/row.dart';
 import 'routes/container.dart';
 
@@ -51,6 +52,12 @@ class _ListBuilderState extends State<ListBuilder> {
           implementation: ImageImplementation(),
           description: ImageDescription(),
           link: "https://api.flutter.dev/flutter/widgets/Image-class.html",
+      ),
+      WidgetModel(
+        name: "Icon",
+        implementation: IconImplementation(),
+        description: IconDescription(),
+        link: "https://api.flutter.dev/flutter/widgets/Icon-class.html",
       ),
     ];
 


### PR DESCRIPTION
This fixes issue #13 
Preview of icon widget implementation:
![85d03d43-c061-4e47-931d-02068dd5e195](https://user-images.githubusercontent.com/31801256/158009193-8d11590a-4ba8-42e0-8aee-6b99b7a197d4.jpg)
![90172d00-183f-4214-8a60-fb318a2e4b21](https://user-images.githubusercontent.com/31801256/158009199-6ffa5b47-7259-47ad-9fb2-fd8ee6fb327f.jpg)

Changes I have made:

1. Added icon.dart file in /lib/routes implementing the icon widget.
2. Updated the widget_list.dart in /lib to reflect the changes.